### PR TITLE
fix for console.log.apply

### DIFF
--- a/src/echo.coffee
+++ b/src/echo.coffee
@@ -184,11 +184,11 @@ Echo = (dump) ->
     if isNeedToPrint(options)
 
       _('info warn error'.split(' ')).each (level) ->
-        if stringLevels[level] == options.level and console?[level]?
+        if stringLevels[level] == options.level and console?[level]? and typeof console[level] is 'function'
           console[level].apply(console, body)
           return
 
-      console.log.apply(console, body) if console?.log?
+      console.log.apply(console, body) if console?.log? and typeof console.log is 'function'
 
   ###
     Internal: Trim logs by rules


### PR DESCRIPTION
Console.log (or console.info/warn/etc.) should be a function, but in some cases (IE9) it is not and logger crashes
